### PR TITLE
Hotfix/bugs spotted

### DIFF
--- a/app/models/deal.rb
+++ b/app/models/deal.rb
@@ -79,7 +79,7 @@ class Deal < ActiveRecord::Base
   def valid_period
     payment = Payment.where(:merchant_id => merchant_id)
     payment.each do |p|
-      if DateTime.now.strftime('%Y/%m/%d') >= p.start_date.strftime('%Y/%m/%d') && DateTime.now.strftime('%Y/%m/%d') <= p.expiry_date.strftime('%Y/%m/%d')
+      if Date.today >= p.start_date && Date.today <= p.expiry_date
         if start_date >= p.start_date && start_date <= p.expiry_date && expiry_date >= p.start_date && expiry_date <= p.expiry_date
           return false
         end

--- a/app/models/deal.rb
+++ b/app/models/deal.rb
@@ -79,7 +79,7 @@ class Deal < ActiveRecord::Base
   def valid_period
     payment = Payment.where(:merchant_id => merchant_id)
     payment.each do |p|
-      if DateTime.now >= p.start_date && DateTime.now <= p.expiry_date
+      if DateTime.now.strftime('%Y/%m/%d') >= p.start_date.strftime('%Y/%m/%d') && DateTime.now.strftime('%Y/%m/%d') <= p.expiry_date.strftime('%Y/%m/%d')
         if start_date >= p.start_date && start_date <= p.expiry_date && expiry_date >= p.start_date && expiry_date <= p.expiry_date
           return false
         end

--- a/app/models/venue.rb
+++ b/app/models/venue.rb
@@ -17,7 +17,6 @@ class Venue < ActiveRecord::Base
 
   validates(:name, presence: true)
   validates(:street, presence: true)
-  validates(:address_2, presence: true)
   validates(:zipcode,presence: true)
   validates(:zipcode, :numericality => {:only_integer => true})
   validates(:neighbourhood, presence: true)

--- a/app/services/deal_service.rb
+++ b/app/services/deal_service.rb
@@ -5,7 +5,7 @@ class DealService
     def num_active_deals (merchant_id, deal)
       all_deals = Deal.where(:merchant_id => merchant_id)
       valid_deals = all_deals.where('expiry_date >= ?', Date.today)
-      active_deals = valid_deals.where('expiry_date > ? AND active = true', Date.today)
+      active_deals = valid_deals.where('expiry_date >= ? AND active = true', Date.today)
       active_deals.count
     end
 

--- a/app/services/deal_service.rb
+++ b/app/services/deal_service.rb
@@ -5,7 +5,7 @@ class DealService
     def num_active_deals (merchant_id, deal)
       all_deals = Deal.where(:merchant_id => merchant_id)
       valid_deals = all_deals.where('expiry_date >= ?', DateTime.now)
-      active_deals = valid_deals.where('start_date = ? OR expiry_date = ? OR (start_date < ? AND expiry_date > ?) OR (expiry_date > ? AND active = true)', DateTime.now, DateTime.now, DateTime.now, DateTime.now, DateTime.now)
+      active_deals = valid_deals.where('expiry_date > ? AND active = true', DateTime.now)
       active_deals.count
     end
 

--- a/app/services/deal_service.rb
+++ b/app/services/deal_service.rb
@@ -4,8 +4,8 @@ class DealService
 
     def num_active_deals (merchant_id, deal)
       all_deals = Deal.where(:merchant_id => merchant_id)
-      valid_deals = all_deals.where('expiry_date >= ?', DateTime.now)
-      active_deals = valid_deals.where('expiry_date > ? AND active = true', DateTime.now)
+      valid_deals = all_deals.where('expiry_date >= ?', Date.today)
+      active_deals = valid_deals.where('expiry_date > ? AND active = true', Date.today)
       active_deals.count
     end
 
@@ -56,9 +56,9 @@ class DealService
 
     def up_coming_deals
       all_deals = Deal.all
-      valid_deals = all_deals.where('expiry_date >= ? AND active = true', DateTime.now)
+      valid_deals = all_deals.where('expiry_date >= ? AND active = true', Date.today)
       future_date = Time.now + 7.days
-      valid_deals.where('start_date > ? AND start_date <= ?', DateTime.now, future_date)
+      valid_deals.where('start_date > ? AND start_date <= ?', Date.today, future_date)
     end
 
     def get_active_deals

--- a/app/services/payment_service.rb
+++ b/app/services/payment_service.rb
@@ -4,7 +4,7 @@ class PaymentService
 
     def get_overlapping_payments(merchant_id, new_start_date)
       all_payments = Payment.where(:merchant_id => merchant_id)
-      valid_payments = all_payments.where('expiry_date >= ? AND paid = ? AND plan1 = ?', DateTime.now, true, true)
+      valid_payments = all_payments.where('expiry_date >= ? AND paid = ? AND plan1 = ?', Date.today, true, true)
       overlapping_payments = valid_payments.where('expiry_date >= ?', new_start_date)
       overlapping_payments.count
     end

--- a/app/services/venue_service.rb
+++ b/app/services/venue_service.rb
@@ -26,7 +26,7 @@ class VenueService
       all_deal_venue = DealVenue.where(:venue_id => venue_id)
       active_deals = []
       all_deal_venue.each do |d|
-        active_deals << Deal.where('expiry_date > ? AND active = true', d.deal_id, Date.today)
+        active_deals << Deal.where('expiry_date >= ? AND active = true', Date.today)
       end
       active_deals
     end

--- a/app/services/venue_service.rb
+++ b/app/services/venue_service.rb
@@ -26,7 +26,7 @@ class VenueService
       all_deal_venue = DealVenue.where(:venue_id => venue_id)
       active_deals = []
       all_deal_venue.each do |d|
-        active_deals << Deal.where('id = ? AND expiry_date >= ? AND (start_date = ? OR expiry_date = ? OR (start_date < ? AND expiry_date > ?) OR (expiry_date > ? AND active = true))', d.deal_id, DateTime.now, DateTime.now, DateTime.now, DateTime.now, DateTime.now, DateTime.now)
+        active_deals << Deal.where('expiry_date > ? AND active = true', d.deal_id, DateTime.now)
       end
       active_deals
     end

--- a/app/services/venue_service.rb
+++ b/app/services/venue_service.rb
@@ -26,7 +26,7 @@ class VenueService
       all_deal_venue = DealVenue.where(:venue_id => venue_id)
       active_deals = []
       all_deal_venue.each do |d|
-        active_deals << Deal.where('expiry_date > ? AND active = true', d.deal_id, DateTime.now)
+        active_deals << Deal.where('expiry_date > ? AND active = true', d.deal_id, Date.today)
       end
       active_deals
     end

--- a/app/views/form/_deal_index_form.erb
+++ b/app/views/form/_deal_index_form.erb
@@ -19,7 +19,7 @@
       </tr>
 
       <% @deals.each do |deal| %>
-          <% if deal.start_date.today? || deal.expiry_date.today? || (deal.start_date.past? && deal.expiry_date.future?) || (deal.expiry_date.future? && deal.active) %>
+          <% if (deal.expiry_date.future? && deal.active) %>
               <tr>
                 <td><%= deal.title %></td>
                 <td><%= image_tag deal.image.url, :size => "100x100" %></td>

--- a/app/views/form/_deal_index_form.erb
+++ b/app/views/form/_deal_index_form.erb
@@ -19,7 +19,7 @@
       </tr>
 
       <% @deals.each do |deal| %>
-          <% if (deal.expiry_date.future? && deal.active) %>
+          <% if (deal.expiry_date.future?|| deal.expiry_date.today?) && deal.active %>
               <tr>
                 <td><%= deal.title %></td>
                 <td><%= image_tag deal.image.url, :size => "100x100" %></td>

--- a/app/views/form/_venue_create_form.erb
+++ b/app/views/form/_venue_create_form.erb
@@ -14,7 +14,7 @@
       </p>
 
       <p class="form-text half clearfix">
-        <%= f.label "Mall / Unit Number*" %>
+        <%= f.label "Mall / Unit Number" %>
         <span><%= f.text_field :address_2, :class => 'half' %></span>
       </p>
       <p class="form-text half clearfix">

--- a/app/views/form/_venue_edit_form.erb
+++ b/app/views/form/_venue_edit_form.erb
@@ -14,7 +14,7 @@
       </p>
 
       <p class="form-text half clearfix">
-        <%= f.label "Mall / Unit Number*" %>
+        <%= f.label "Mall / Unit Number" %>
         <span><%= f.text_field :address_2, :class => 'half' %></span>
       </p>
       <p class="form-text half clearfix">


### PR DESCRIPTION
@junwen29 @jkcheong92 

Sorry can please ignore the last commit of  "Removed the compulsory need for mall/unit number when listing venue" I realise this might cause problems for android view page side

I realised that DateTime.now cannot be used to compare our Date variables in our table as they are different variables. DateTime.now gives back the current time as well so it will cause some validation errors. I changed it to Date.today which returns today as a Date attribute. So I changed all DateTime.now i can find to Date.today and tested.

Also realised that since we are now making users activate the deals themselves my previous validation to find active deals has become void. However, I forgot to change until now resulting in several bugs.

Along the way also realised some other bugs in deals which i've fixed

Sorry for the trouble caused ><