### PR TITLE
Realised my start time for view count is in DateTime but for Redempti…

### DIFF
--- a/app/services/deal_analytic_service.rb
+++ b/app/services/deal_analytic_service.rb
@@ -83,7 +83,7 @@ class DealAnalyticService
         deal_array = Array.new
         view_start_date = Viewcount.where(:deal_id => d.id).first
         if view_start_date.blank?
-          view_start_date = Date.today
+          view_start_date = DateTime.now.in_time_zone("Singapore").beginning_of_day
         else
           view_start_date = view_start_date.created_at.beginning_of_day
         end
@@ -91,9 +91,9 @@ class DealAnalyticService
 
         # If start date of deal is after given start date, we will start from deal start date
         if d.start_date > start_date
-          redemption_start_date = d.start_date
+          redemption_start_date = d.start_date.beginning_of_day
         else
-          redemption_start_date = start_date
+          redemption_start_date = start_date.beginning_of_day
         end
 
         # If end date of deal is before given end date, we will end at deal end date


### PR DESCRIPTION
…on is in Date.

Suspect it is one of the problem result in deal analytics graph on heroku to be mismatch
However cannot be totally sure as testing on local does not give the error at all.

@junwen29 @jkcheong92 
This code has to be tested on heroku as on local it does not give any changes.
It is to solve the issue of cannot compare between view counts and redemption counts. Suspect is due to start point of Viewcounts to be in DateTime while Redemption count is in Date.